### PR TITLE
Sort projects on dashboard and add jigsaw-site project

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -13,7 +13,7 @@ class DashboardController extends Controller
     {
         /* At the moment I don't trust our GitHub package to be caching correctly. */
         $projects = Cache::remember('projects', 60, function () {
-            $projects = collect(json_decode(file_get_contents(base_path('projects.json'))));
+            $projects = collect(json_decode(file_get_contents(base_path('projects.json'))))->sortBy('name');
 
             return $projects->map(function ($project) {
                 return new Project($project->namespace, $project->name, $project->maintainer);

--- a/projects.json
+++ b/projects.json
@@ -63,5 +63,10 @@
         "name": "ozzie",
         "namespace": "tightenco",
         "maintainer": "mattstauffer"
+    },
+    {
+        "name": "jigsaw-site",
+        "namespace": "tightenco",
+        "maintainer": "damiani"
     }
 ]


### PR DESCRIPTION
This PR does two things:

- Add `jigsaw-site` to the projects list in `projects.json`
- Sort the collection of projects pulled from this file, so that scrolling through the dashboard page has them listed in alphabetical order (this doesn't change the table being sorted by debt score)