### PR TITLE
Add support for multiple maintainers

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -16,7 +16,7 @@ class DashboardController extends Controller
             $projects = collect(json_decode(file_get_contents(base_path('projects.json'))))->sortBy('name');
 
             return $projects->map(function ($project) {
-                return new Project($project->namespace, $project->name, $project->maintainer);
+                return new Project($project->namespace, $project->name, $project->maintainers);
             });
         });
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -12,14 +12,14 @@ class Project
     protected $issues;
     protected $namespace;
     protected $name;
-    protected $maintainer;
+    protected $maintainers;
     protected $github;
 
-    public function __construct($namespace, $name, $maintainer)
+    public function __construct($namespace, $name, $maintainers)
     {
         $this->namespace = $namespace;
         $this->name = $name;
-        $this->maintainer = $maintainer;
+        $this->maintainers = $maintainers;
 
         $this->github = app('mygithub');
 
@@ -49,7 +49,7 @@ class Project
 
     public function __get($key)
     {
-        if (in_array($key, ['name', 'namespace', 'maintainer'])) {
+        if (in_array($key, ['name', 'namespace', 'maintainers'])) {
             return $this->$key;
         }
 

--- a/projects.json
+++ b/projects.json
@@ -2,71 +2,99 @@
     {
         "name": "giscus",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "gistlog",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "mailthief",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "collect",
         "namespace": "tightenco",
-        "maintainer": "besologic"
+        "maintainers": [
+            "besologic"
+        ]
     },
     {
         "name": "jigsaw",
         "namespace": "tightenco",
-        "maintainer": "damiani"
+        "maintainers": [
+            "damiani"
+        ]
     },
     {
         "name": "symposium",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "confomo",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "quicksand",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "lambo",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "torch",
         "namespace": "mattstauffer",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "ziggy",
         "namespace": "tightenco",
-        "maintainer": "DanielCoulbourne"
+        "maintainers": [
+            "DanielCoulbourne"
+        ]
     },
     {
         "name": "tlint",
         "namespace": "tightenco",
-        "maintainer": "loganhenson"
+        "maintainers": [
+            "loganhenson"
+        ]
     },
     {
         "name": "ozzie",
         "namespace": "tightenco",
-        "maintainer": "mattstauffer"
+        "maintainers": [
+            "mattstauffer"
+        ]
     },
     {
         "name": "jigsaw-site",
         "namespace": "tightenco",
-        "maintainer": "damiani"
+        "maintainers": [
+            "damiani"
+        ]
     }
 ]

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -54,7 +54,7 @@
                                     <a class="text-indigo no-underline text-md" href="#project-{{ $project->namespace }}-{{ $project->name }}">
                                         {{ $project->namespace }}/{{ $project->name }}
                                     </a>
-                                </li">
+                                </li>
 
                                 <li class="w-1/7 text-black-lightest">{{ number_format($project->debtScore(), 2) }}</li>
 
@@ -80,7 +80,9 @@
                             <p class="w-1/2 text-right text-black-lightest">
                                 Maintained by 
 
-                                <a class="text-indigo no-underline" href="https://github.com/{{ $project->maintainer }}">{{ $project->maintainer }}</a>
+                                @foreach ($project->maintainers as $maintainer)
+                                    <a class="text-indigo no-underline" href="https://github.com/{{ $maintainer }}">{{ '@' . $maintainer }}</a>
+                                @endforeach
                             </p>
                         </section>
 
@@ -104,7 +106,7 @@
                                         </div>
 
                                         <div class="py-6 w-auto">
-                                            <a class="no-underline" href="{{ $pr['html_url'] }}"">
+                                            <a class="no-underline" href="{{ $pr['html_url'] }}">
                                                 @include('svg.launch')
                                             </a>
                                         </div>


### PR DESCRIPTION
This PR changes the `maintainer` string to a `maintainers` array throughout the app, addressing #3.

The issue also suggested implementing a "main" person designation but I didn't include that here; I figured it's safe to assume the first person in the list is the primary maintainer for now.