### PR TITLE
Add stats/links for Hacktoberfest 🎃

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Project;
 use GrahamCampbell\GitHub\Facades\GitHub;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 class DashboardController extends Controller
@@ -20,6 +21,10 @@ class DashboardController extends Controller
             });
         });
 
-        return view('dashboard')->with('projects', $projects);
+        $hacktoberfest = (bool)Carbon::now()->isSameMonth(Carbon::parse('October'));
+
+        return view('dashboard')
+            ->with('projects', $projects)
+            ->with('hacktoberfest', $hacktoberfest);
     }
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -56,6 +56,14 @@ class Project
         throw new Exception('No such property ' . $key);
     }
 
+    public function hacktoberfestIssues()
+    {
+        return $this->issues->filter(function ($issue) {
+            return ! empty($issue['labels'])
+                && collect($issue['labels'])->contains('name', 'hacktoberfest');
+        });
+    }
+
     public function oldPrs()
     {
         return $this->prs->filter(function ($pr) {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -30,7 +30,15 @@
 
         <div class="bg-frost font-sans relative z-0">
             <div class="max-w-lg mx-auto pt-8">
-                <p class="mb-6 text-black-lighter">Projects in descending order of "get-your-poop-in-a-group-ness"</p>
+                <div class="flex items-center justify-between">
+                    <p class="mb-6 text-black-lighter">Projects in descending order of "get-your-poop-in-a-group-ness"</p>
+
+                    @if ($hacktoberfest)
+                        <a href="https://github.com/search?o=desc&q=label%3Ahacktoberfest+is%3Aopen+type%3Aissue+user%3Atightenco&s=created&type=Issues" target="_blank" class="mb-6 px-4 py-3 bg-grey-blue no-underline rounded-lg text-black-lighter">
+                            Hacktoberfest is here! 👻
+                        </a>
+                    @endif
+                </div>
 
                 <div class="rounded-lg shadow">
                     <ul class="bg-grey-blue-light flex list-reset p-4 rounded-t-lg border-grey border-b-2">
@@ -38,13 +46,17 @@
 
                         <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">debt score</li>
 
-                        <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">old pr's</li>
+                        <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">old prs</li>
 
                         <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">old issues</li>
 
-                        <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">pr's</li>
+                        <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">prs</li>
 
                         <li class="w-1/7 text-grey-darker font-semibold uppercase text-xs tracking-wide">issues</li>
+
+                        @if ($hacktoberfest)
+                            <li class="w-4 text-xs">🎃</li>
+                        @endif
                     </ul>
 
                     <section class="bg-white rounded-b-lg">
@@ -65,6 +77,14 @@
                                 <li class="w-1/7 text-black-lightest">{{ $project->prs()->count() }}</li>
 
                                 <li class="w-1/7 text-black-lightest">{{ $project->issues()->count() }}</li>
+
+                                @if ($hacktoberfest)
+                                    <li class="w-4">
+                                        <a class="text-indigo no-underline" href="https://github.com/{{ $project->namespace }}/{{ $project->name }}/labels/hacktoberfest" target="_blank">
+                                            {{ $project->hacktoberfestIssues()->count() }}
+                                        </a>
+                                    </li>
+                                @endif
                             </ul>
                         @endforeach
                     </section>
@@ -78,7 +98,7 @@
                             </h2>
 
                             <p class="w-1/2 text-right text-black-lightest">
-                                Maintained by 
+                                Maintained by
 
                                 @foreach ($project->maintainers as $maintainer)
                                     <a class="text-indigo no-underline" href="https://github.com/{{ $maintainer }}" target="_blank">{{ '@' . $maintainer }}</a>


### PR DESCRIPTION
This PR adds a button to the top of the dashboard during the month of October, linking [to these search results](https://github.com/search?o=desc&q=label%3Ahacktoberfest+is%3Aopen+type%3Aissue+user%3Atightenco&s=created&type=Issues). It also adds a `hacktoberfest` label count/link to each project's row in the table. Unrelated: I also removed some unnecessary apostrophes in the column titles.

Fixes #16 (with a little pumpkin or a ghost or something, as requested 😄)

![image](https://user-images.githubusercontent.com/1902973/66885346-dfbff200-ef88-11e9-9db8-d9086b0985dc.png)
