### PR TITLE
Use a table to format CLI stats

### DIFF
--- a/app/Console/Commands/OutputStats.php
+++ b/app/Console/Commands/OutputStats.php
@@ -15,12 +15,28 @@ class OutputStats extends Command
     {
         $this->info("\n\n");
 
-        $projects->all()->sortByDesc(function ($project) {
-            return $project->debtScore();
-        })->each(function ($project) {
-            $this->info($project->name);
-            $this->comment("-----------------------");
-            $this->info('Debt score: ' . $project->debtScore() . "\n\n");
-        });
+        $this->table(
+            ['Project', 'Debt Score'],
+            $projects->all()->sortByDesc(function ($project) {
+                return $project->debtScore();
+            })->map(function ($project) {
+                return [
+                    $project->name,
+                    $this->formatDebtScore($project->debtScore()),
+                ];
+            })
+        );
+    }
+
+    protected function formatDebtScore(float $debtScore): string
+    {
+        if ($debtScore > 5) {
+            return sprintf('<error>%s</error>', $debtScore);
+        }
+        if ($debtScore > 1) {
+            return sprintf('<comment>%s</comment>', $debtScore);
+        }
+
+        return $debtScore;
     }
 }

--- a/app/Console/Commands/OutputStats.php
+++ b/app/Console/Commands/OutputStats.php
@@ -13,7 +13,7 @@ class OutputStats extends Command
 
     public function handle(Projects $projects)
     {
-        $this->info("\n\n");
+        $this->info("\n");
 
         $this->table(
             ['Project', 'Debt Score'],
@@ -26,6 +26,8 @@ class OutputStats extends Command
                 ];
             })
         );
+
+        $this->info("\n");
     }
 
     protected function formatDebtScore(float $debtScore): string


### PR DESCRIPTION
This PR updates the stats CLI output to use a table format (condensing it significantly) and adds some score-based color coding, like the Slack message.

before:
![image](https://user-images.githubusercontent.com/1902973/69460817-e715b080-0d29-11ea-94c6-1836e0962e9d.png)

after:
![image](https://user-images.githubusercontent.com/1902973/69460757-c3eb0100-0d29-11ea-8458-9b01d9224a69.png)
