### PR TITLE
Use Block Kit to shorten the Slack stats output

### DIFF
--- a/app/Notifications/SendOzzieStats.php
+++ b/app/Notifications/SendOzzieStats.php
@@ -3,8 +3,8 @@
 namespace App\Notifications;
 
 use App\Projects;
-use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use NathanHeffley\LaravelSlackBlocks\Messages\SlackMessage;
 
 class SendOzzieStats extends Notification
 {
@@ -16,20 +16,70 @@ class SendOzzieStats extends Notification
     public function toSlack($notifiable)
     {
         $message = (new SlackMessage)
-            ->from('Ozzie', ':robot:')
-            ->content("Here are your Ozzie Stats!\nhttps://ozzie.tighten.co/");
+            ->from('Ozzie', ':robot_face:')
+            // Provide a text-only fallback message
+            ->content('Here are your Ozzie stats! %s', config('app.url'))
+            ->block(function ($block) {
+                $block
+                    ->type('section')
+                    ->text([
+                        'type' => 'mrkdwn',
+                        'text' => 'Here are your Ozzie stats!',
+                    ])
+                    ->accessory([
+                        'type' => 'button',
+                        'url' => config('app.url'),
+                        'text' => [
+                            'type' => 'plain_text',
+                            'text' => 'Open Ozzie',
+                            'emoji' => true,
+                        ],
+                    ]);
+            });
 
         app(Projects::class)->all()->sortByDesc(function ($project) {
             return $project->debtScore();
         })->each(function ($project) use ($message) {
             $message->attachment(function ($attachment) use ($project) {
                 $scoreMoji = $project->debtScore() < 1 ? ':white_check_mark: ' : ':warning: ';
-                $attachment->title(ucwords($project->name), $project->url())
-                    ->fields([
-                        'Debt Score' => $scoreMoji . $project->debtScore(),
-                        'PRs' => sprintf("%s (%s old)", $project->prs()->count(), $project->oldPrs()->count()),
-                        'Issues' => sprintf("%s (%s old)", $project->issues()->count(), $project->oldIssues()->count()),
-                    ]);
+                $hexColor = $project->debtScore() < 1 ? '#44AB31': '#F9C336';
+                $attachment
+                    ->color($hexColor)
+                    ->block(function ($block) use ($project) {
+                        $block
+                            ->type('section')
+                            ->text([
+                                'type' => 'mrkdwn',
+                                'text' => sprintf(
+                                    '*<%s|%s>*: *%s*',
+                                    $project->url(),
+                                    ucwords($project->name),
+                                    $project->debtScore()
+                                ),
+                            ]);
+                    })
+                    ->block(function ($block) use ($project, $scoreMoji) {
+                        $block
+                            ->type('context')
+                            ->elements([
+                                [
+                                    'type' => 'plain_text',
+                                    'emoji' => true,
+                                    'text' => $scoreMoji,
+                                ],
+                                [
+                                    'type' => 'mrkdwn',
+                                    'text' => sprintf(
+                                        "PRs: %s (*%s old*)\t\t\tIssues: %s (*%s old*)",
+                                        $project->prs()->count(),
+                                        $project->oldPrs()->count(),
+                                        $project->issues()->count(),
+                                        $project->oldIssues()->count()
+                                    ),
+                                ]
+                            ]);
+                    })
+                    ->dividerBlock();
             });
         });
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "graham-campbell/github": "^8.3",
         "laravel/framework": "^6.2",
         "laravel/tinker": "^1.0",
+        "nathanheffley/laravel-slack-blocks": "^2.1",
         "php-http/guzzle6-adapter": "^1.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc1d1e6f9a752b9caae9ea788ccea1a0",
+    "content-hash": "9873f854ec8bafaf2f5d69005ccc6eb4",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1059,6 +1059,63 @@
             "time": "2019-11-12T15:20:18+00:00"
         },
         {
+            "name": "laravel/slack-notification-channel",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/slack-notification-channel.git",
+                "reference": "ecc90a70791195d6f5e20b2732a5eb1eb9619d10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/slack-notification-channel/zipball/ecc90a70791195d6f5e20b2732a5eb1eb9619d10",
+                "reference": "ecc90a70791195d6f5e20b2732a5eb1eb9619d10",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "illuminate/notifications": "~5.8.0|^6.0|^7.0",
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Illuminate\\Notifications\\SlackChannelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Notifications\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Slack Notification Channel for laravel.",
+            "keywords": [
+                "laravel",
+                "notifications",
+                "slack"
+            ],
+            "time": "2019-08-27T14:40:26+00:00"
+        },
+        {
             "name": "laravel/tinker",
             "version": "v1.0.10",
             "source": {
@@ -1285,6 +1342,62 @@
                 "psr-3"
             ],
             "time": "2019-11-13T10:27:43+00:00"
+        },
+        {
+            "name": "nathanheffley/laravel-slack-blocks",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nathanheffley/laravel-slack-blocks.git",
+                "reference": "3e895b9eeb65355f7fb6c2bdb7788f61a4086451"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nathanheffley/laravel-slack-blocks/zipball/3e895b9eeb65355f7fb6c2bdb7788f61a4086451",
+                "reference": "3e895b9eeb65355f7fb6c2bdb7788f61a4086451",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "laravel/slack-notification-channel": "^2.0",
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "illuminate/notifications": "~5.8",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NathanHeffley\\LaravelSlackBlocks\\SlackChannelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NathanHeffley\\LaravelSlackBlocks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nathan Heffley",
+                    "email": "nathan@nathanheffley.com"
+                }
+            ],
+            "description": "Slack Blocks support for laravel notifications.",
+            "keywords": [
+                "blocks",
+                "laravel",
+                "notifications",
+                "slack"
+            ],
+            "time": "2019-11-22T22:46:22+00:00"
         },
         {
             "name": "nesbot/carbon",


### PR DESCRIPTION
This PR re-formats the Slack stats output using Slack's [Block Kit API](https://api.slack.com/block-kit) and the [nathanheffley/laravel-slack-blocks](https://github.com/nathanheffley/laravel-slack-blocks) package, condensing the size of the message. See #23 for more details.

Screenshots:
![image](https://user-images.githubusercontent.com/1902973/69466952-ea656800-0d3a-11ea-832a-84405e4525d1.png)

Fixes #23.