### PR TITLE
Convert projects to a <table>, fix mobile view

### DIFF
--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -11,7 +11,7 @@
 </div>
 
 <div class="overflow-x-auto max-w-full">
-<table class="table-auto rounded-lg shadow max-w-full">
+<table class="table-auto rounded-lg shadow w-full">
     <thead class="bg-grey-blue-light border-grey border-b-2 text-left">
         <tr>
             <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Project Name</th>
@@ -35,8 +35,8 @@
     <tbody class="bg-white rounded-b-lg">
         @foreach ($projects->sortByDesc(function ($project) { return $project->debtScore(); }) as $project)
             <tr class="border-t border-smoke">
-                <td>
-                    <a class="text-indigo no-underline text-md p-4"
+                <td class="p-4">
+                    <a class="text-indigo no-underline text-md p-2 -mx-2"
                        href="#project-{{ $project->namespace }}-{{ $project->name }}">
                         {{ $project->namespace }}/{{ $project->name }}
                     </a>
@@ -53,8 +53,8 @@
                 <td class="text-black-lightest p-4">{{ $project->issues()->count() }}</td>
 
                 @if ($hacktoberfest)
-                    <td>
-                        <a class="text-indigo no-underline p-4"
+                    <td class="p-4">
+                        <a class="text-indigo no-underline p-2 -mx-2"
                            href="https://github.com/{{ $project->namespace }}/{{ $project->name }}/labels/hacktoberfest"
                            target="_blank">
                             {{ $project->hacktoberfestIssues()->count() }}

--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -10,7 +10,8 @@
     @endif
 </div>
 
-<table class="table-auto rounded-lg shadow max-w-full overflow-x-scroll">
+<div class="overflow-x-auto max-w-full">
+<table class="table-auto rounded-lg shadow max-w-full">
     <thead class="bg-grey-blue-light border-grey border-b-2 text-left">
         <tr>
             <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Project Name</th>
@@ -64,3 +65,4 @@
         @endforeach
     </tbody>
 </table>
+</div>

--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -10,55 +10,57 @@
     @endif
 </div>
 
-<div class="rounded-lg shadow">
-    <ul class="bg-grey-blue-light flex p-4 rounded-t-lg border-grey border-b-2">
-        <li class="w-2/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Project Name</li>
+<table class="table-auto rounded-lg shadow max-w-full overflow-x-scroll">
+    <thead class="bg-grey-blue-light border-grey border-b-2 text-left">
+        <tr>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Project Name</th>
 
-        <li class="w-1/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Debt Score</li>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Debt Score</th>
 
-        <li class="w-1/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Old Prs</li>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Old Prs</th>
 
-        <li class="w-1/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Old Issues</li>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Old Issues</th>
 
-        <li class="w-1/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Prs</li>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Prs</th>
 
-        <li class="w-1/7 text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide">Issues</li>
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Issues</th>
 
-        @if ($hacktoberfest)
-            <li class="w-4 text-xs">🎃</li>
-        @endif
-    </ul>
+            @if ($hacktoberfest)
+                <th class="text-xs p-4">🎃</th>
+            @endif
+        </tr>
+    </thead>
 
-    <section class="bg-white rounded-b-lg">
+    <tbody class="bg-white rounded-b-lg">
         @foreach ($projects->sortByDesc(function ($project) { return $project->debtScore(); }) as $project)
-            <ul class="flex justify-between list-reset p-3 border-t border-smoke">
-                <li class="w-2/7">
-                    <a class="text-indigo no-underline text-md"
+            <tr class="border-t border-smoke">
+                <td>
+                    <a class="text-indigo no-underline text-md p-4"
                        href="#project-{{ $project->namespace }}-{{ $project->name }}">
                         {{ $project->namespace }}/{{ $project->name }}
                     </a>
-                </li>
+                </td>
 
-                <li class="w-1/7 text-black-lightest">{{ number_format($project->debtScore(), 2) }}</li>
+                <td class="text-black-lightest p-4">{{ number_format($project->debtScore(), 2) }}</td>
 
-                <li class="w-1/7 text-black-lightest">{{ $project->oldPrs()->count() }}</li>
+                <td class="text-black-lightest p-4">{{ $project->oldPrs()->count() }}</td>
 
-                <li class="w-1/7 text-black-lightest">{{ $project->oldIssues()->count() }}</li>
+                <td class="text-black-lightest p-4">{{ $project->oldIssues()->count() }}</td>
 
-                <li class="w-1/7 text-black-lightest">{{ $project->prs()->count() }}</li>
+                <td class="text-black-lightest p-4">{{ $project->prs()->count() }}</td>
 
-                <li class="w-1/7 text-black-lightest">{{ $project->issues()->count() }}</li>
+                <td class="text-black-lightest p-4">{{ $project->issues()->count() }}</td>
 
                 @if ($hacktoberfest)
-                    <li class="w-4">
-                        <a class="text-indigo no-underline"
+                    <td>
+                        <a class="text-indigo no-underline p-4"
                            href="https://github.com/{{ $project->namespace }}/{{ $project->name }}/labels/hacktoberfest"
                            target="_blank">
                             {{ $project->hacktoberfestIssues()->count() }}
                         </a>
-                    </li>
+                    </td>
                 @endif
-            </ul>
+            </tr>
         @endforeach
-    </section>
-</div>
+    </tbody>
+</table>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -26,7 +26,7 @@
             </section>
         </div>
 
-        <div id="app" class="bg-frost font-sans relative overflow-x-scroll z-0">
+        <div id="app" class="bg-frost font-sans relative overflow-x-auto z-0">
             <div class="max-w-4xl mx-auto px-2 py-6">
                 <x-debt-table :projects="$projects" :hacktoberfest="$hacktoberfest"/>
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -26,8 +26,8 @@
             </section>
         </div>
 
-        <div id="app" class="bg-frost font-sans relative z-0">
-            <div class="max-w-4xl mx-auto py-6">
+        <div id="app" class="bg-frost font-sans relative overflow-x-scroll z-0">
+            <div class="max-w-4xl mx-auto px-2 py-6">
                 <x-debt-table :projects="$projects" :hacktoberfest="$hacktoberfest"/>
 
                 @foreach ($projects as $project)

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -13,7 +13,7 @@
 
     <body>
         <div class="bg-white border-t-4 border-indigo relative z-10 shadow">
-            <section class="max-w-4xl mx-auto">
+            <section class="max-w-4xl mx-auto px-2">
                 <div class="flex justify-between items-center">
                     <h1 class="flex items-center">
                         <span class="text-5xl text-indigo font-montserrat">O</span>


### PR DESCRIPTION
This PR fixes #36 by converting the projects table from divs & lists to a `<table class="table-auto">` and adding `overflow-x-scroll` to the main page div.

## Screenshots

Before:
![ozzie test_(iPhone X) (before)](https://user-images.githubusercontent.com/1902973/84533481-6e664980-aca5-11ea-9d97-2f5ff4392a86.png)

After:
![ozzie test_(iPhone X) (after)](https://user-images.githubusercontent.com/1902973/84533489-71f9d080-aca5-11ea-85f7-b865f3143a65.png)
