### PR TITLE
Fix Dto errors by defining $active_lock_reason

### DIFF
--- a/app/GitHub/Dto/Issue.php
+++ b/app/GitHub/Dto/Issue.php
@@ -32,6 +32,7 @@ class Issue extends DataTransferObject
     public $labels;
     public $state;
     public $locked;
+    public $active_lock_reason;
     public $milestone;
 
     // People ------------------------------------------------------------------

--- a/app/GitHub/Dto/Pr.php
+++ b/app/GitHub/Dto/Pr.php
@@ -32,6 +32,7 @@ class Pr extends DataTransferObject
     public $labels;
     public $state;
     public $locked;
+    public $active_lock_reason;
     public $milestone;
     public $draft;
 


### PR DESCRIPTION
This PR fixes the following errors by defining the `$active_lock_reason` field, which is presumably new:

```
Public properties `active_lock_reason` not found on App\GitHub\Dto\Pr
Public properties `active_lock_reason` not found on App\GitHub\Dto\Issue
```