### PR TITLE
Add missing sprintf and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Ozzie
 **Ozzie** Tighten's Open Source Projects Monitor
 
 ## Local Development
-1. Clone the repo.
-2. run `composer install`
+1. Clone the repo
+2. Run `composer install`
 3. Copy the .env example file: `cp .env.example .env`
 4. Create an Oauth Application on [GitHub](https://github.com/settings/developers);
   - If you use `php artisan serve` to serve your application locally, you can use the following settings:
@@ -14,5 +14,5 @@ Ozzie
     - Homepage URL: http://127.0.0.1:8000
     - Application Description: Local Version of Ozzie
     - Authorization Callback URL: http://127.0.0.1:8000/callback
-5. Copy the client ID and secret from the previous step into your .env file.`
-6. run `php artisan serve` and visit http://127.0.0.1:8000
+5. Copy the client ID and secret from the previous step into your .env file
+6. Run `php artisan serve` and visit http://127.0.0.1:8000

--- a/app/Notifications/SendOzzieStats.php
+++ b/app/Notifications/SendOzzieStats.php
@@ -18,7 +18,7 @@ class SendOzzieStats extends Notification
         $message = (new SlackMessage)
             ->from('Ozzie', ':robot_face:')
             // Provide a text-only fallback message
-            ->content('Here are your Ozzie stats! %s', config('app.url'))
+            ->content(sprintf('Here are your Ozzie stats! %s', config('app.url')))
             ->block(function ($block) {
                 $block
                     ->type('section')
@@ -76,7 +76,7 @@ class SendOzzieStats extends Notification
                                         $project->issues()->count(),
                                         $project->oldIssues()->count()
                                     ),
-                                ]
+                                ],
                             ]);
                     })
                     ->dividerBlock();


### PR DESCRIPTION
I missed an `sprintf` in the original Slack text-only URL output, so this PR adds it and makes some minor changes to the README for consistency.