### PR TITLE
Ignore draft PRs in debt score, like `in-progress`

### DIFF
--- a/app/Project.php
+++ b/app/Project.php
@@ -48,8 +48,10 @@ class Project
     public function prs()
     {
         return $this->prs->reject(function ($pr) {
-            return ! empty($pr->labels)
-                && collect($pr->labels)->contains('name', 'in-progress');
+            return $pr->draft || (
+                    ! empty($pr->labels)
+                    && collect($pr->labels)->contains('name', 'in-progress')
+                );
         });
     }
 


### PR DESCRIPTION
Exclude PRs in draft status from the debt score, since we're already excluding those labeled `in-progress`.