### PR TITLE
Update projects and maintainers list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -26,8 +26,7 @@
         "name": "collect",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
-            "damiani"
+            "jamisonvalenta"
         ]
     },
     {
@@ -35,6 +34,7 @@
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
+            "bakerkretzmar",
             "darkboywonder"
         ]
     },
@@ -43,7 +43,7 @@
         "namespace": "tightenco",
         "maintainers": [
             "andrewmile",
-            "josecanhelp"
+            "sariyana"
         ]
     },
     {
@@ -65,16 +65,16 @@
         "name": "lambo",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
-            "andrewmile"
+            "mattstauffer"
         ]
     },
     {
         "name": "ziggy",
         "namespace": "tightenco",
         "maintainers": [
-            "DanielCoulbourne",
-            "jakebathman"
+            "jakebathman",
+            "mattstauffer",
+            "bakerkretzmar"
         ]
     },
     {
@@ -89,7 +89,6 @@
         "name": "ozzie",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
             "jakebathman",
             "sbine"
         ]
@@ -99,6 +98,7 @@
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
+            "bakerkretzmar",
             "darkboywonder"
         ]
     },
@@ -107,6 +107,7 @@
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
+            "bakerkretzmar",
             "darkboywonder"
         ]
     },
@@ -114,8 +115,7 @@
         "name": "onramp",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
-            "sariyana"
+            "mattstauffer"
         ]
     },
     {
@@ -123,15 +123,16 @@
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
+            "bakerkretzmar",
             "darkboywonder"
         ]
     },
     {
-        "name": "version-check",
+        "name": "checkmate",
         "namespace": "tightenco",
         "maintainers": [
-            "jakebathman",
-            "ctroms"
+            "ctroms",
+            "marcusmoore"
         ]
     }
 ]

--- a/projects.json
+++ b/projects.json
@@ -15,20 +15,6 @@
         ]
     },
     {
-        "name": "confomo",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
-        "name": "giscus",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
         "name": "gistlog",
         "namespace": "tightenco",
         "maintainers": [

--- a/projects.json
+++ b/projects.json
@@ -1,5 +1,27 @@
 [
     {
+        "name": "checkmate",
+        "namespace": "tightenco",
+        "maintainers": [
+            "ctroms",
+            "marcusmoore"
+        ]
+    },
+    {
+        "name": "collect",
+        "namespace": "tightenco",
+        "maintainers": [
+            "jamisonvalenta"
+        ]
+    },
+    {
+        "name": "confomo",
+        "namespace": "tightenco",
+        "maintainers": [
+            "mattstauffer"
+        ]
+    },
+    {
         "name": "giscus",
         "namespace": "tightenco",
         "maintainers": [
@@ -16,20 +38,6 @@
         ]
     },
     {
-        "name": "mailthief",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
-        "name": "collect",
-        "namespace": "tightenco",
-        "maintainers": [
-            "jamisonvalenta"
-        ]
-    },
-    {
         "name": "jigsaw",
         "namespace": "tightenco",
         "maintainers": [
@@ -39,62 +47,7 @@
         ]
     },
     {
-        "name": "symposium",
-        "namespace": "tightenco",
-        "maintainers": [
-            "andrewmile",
-            "sariyana"
-        ]
-    },
-    {
-        "name": "confomo",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
-        "name": "quicksand",
-        "namespace": "tightenco",
-        "maintainers": [
-            "josecanhelp",
-            "imjohnbon"
-        ]
-    },
-    {
-        "name": "lambo",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
-        "name": "ziggy",
-        "namespace": "tightenco",
-        "maintainers": [
-            "jakebathman",
-            "mattstauffer",
-            "bakerkretzmar"
-        ]
-    },
-    {
-        "name": "tlint",
-        "namespace": "tightenco",
-        "maintainers": [
-            "loganhenson",
-            "andrewmile"
-        ]
-    },
-    {
-        "name": "ozzie",
-        "namespace": "tightenco",
-        "maintainers": [
-            "jakebathman",
-            "sbine"
-        ]
-    },
-    {
-        "name": "jigsaw-site",
+        "name": "jigsaw-blog-template",
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
@@ -112,14 +65,7 @@
         ]
     },
     {
-        "name": "onramp",
-        "namespace": "tightenco",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
-        "name": "jigsaw-blog-template",
+        "name": "jigsaw-site",
         "namespace": "tightenco",
         "maintainers": [
             "damiani",
@@ -128,11 +74,65 @@
         ]
     },
     {
-        "name": "checkmate",
+        "name": "lambo",
         "namespace": "tightenco",
         "maintainers": [
-            "ctroms",
-            "marcusmoore"
+            "mattstauffer"
+        ]
+    },
+    {
+        "name": "mailthief",
+        "namespace": "tightenco",
+        "maintainers": [
+            "mattstauffer"
+        ]
+    },
+    {
+        "name": "onramp",
+        "namespace": "tightenco",
+        "maintainers": [
+            "mattstauffer"
+        ]
+    },
+    {
+        "name": "ozzie",
+        "namespace": "tightenco",
+        "maintainers": [
+            "jakebathman",
+            "sbine"
+        ]
+    },
+    {
+        "name": "quicksand",
+        "namespace": "tightenco",
+        "maintainers": [
+            "josecanhelp",
+            "imjohnbon"
+        ]
+    },
+    {
+        "name": "symposium",
+        "namespace": "tightenco",
+        "maintainers": [
+            "andrewmile",
+            "sariyana"
+        ]
+    },
+    {
+        "name": "tlint",
+        "namespace": "tightenco",
+        "maintainers": [
+            "loganhenson",
+            "andrewmile"
+        ]
+    },
+    {
+        "name": "ziggy",
+        "namespace": "tightenco",
+        "maintainers": [
+            "jakebathman",
+            "mattstauffer",
+            "bakerkretzmar"
         ]
     }
 ]

--- a/projects.json
+++ b/projects.json
@@ -25,16 +25,14 @@
         "name": "giscus",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
-            "jakebathman"
+            "mattstauffer"
         ]
     },
     {
         "name": "gistlog",
         "namespace": "tightenco",
         "maintainers": [
-            "mattstauffer",
-            "imjohnbon"
+            "mattstauffer"
         ]
     },
     {
@@ -106,8 +104,7 @@
         "name": "quicksand",
         "namespace": "tightenco",
         "maintainers": [
-            "josecanhelp",
-            "imjohnbon"
+            "mattstauffer"
         ]
     },
     {


### PR DESCRIPTION
This PR updates the maintainers to match the latest version of our internal list, and alphabetizes the list of projects. It also renames `version-check` to `checkmate`.

@mattstauffer would you like to remove any of the projects that are only assigned to you?
- Confomo
- Giscus
- Gistlog
- Mailthief
- Quicksand