### PR TITLE
Correctly hide Issues/prs that are labeled 'in progress'.

### DIFF
--- a/app/Project.php
+++ b/app/Project.php
@@ -40,7 +40,7 @@ class Project
     {
         return $this->issues->reject(function ($issue) {
             return ! empty($issue->labels)
-                && collect($issue->labels)->contains('name', 'in-progress');
+                && collect($issue->labels)->contains('name', 'in progress');
         });
     }
 
@@ -49,7 +49,7 @@ class Project
         return $this->prs->reject(function ($pr) {
             return $pr->draft || (
                     ! empty($pr->labels)
-                    && collect($pr->labels)->contains('name', 'in-progress')
+                    && collect($pr->labels)->contains('name', 'in progress')
                 );
         });
     }


### PR DESCRIPTION
The following code is intended to hide any issue/pr that is labeled as 'in progress'. Notice the hyphen.

This PR removes the hyphen so that the label is correctly matched. 

```php
public function issues()
{
    return $this->issues->reject(function ($issue) {
        return ! empty($issue->labels)
            && collect($issue->labels)->contains('name', 'in-progress');
    });
}
```

Note that:
- there are a few projects on Ozzie that do not use the 'in progress' label. Maybe all projects should start using them 🤷 .
- There are some projects that do use the label but on issues/prs that are years old. I'm not sure hiding those is the best idea 🤷 .

For now, maybe the best idea is to accept the PR so that the app functions as designed but maybe
the use of the label should be adopted on all projects or not used at all.
