### PR TITLE
Fix "Public property <PROPERTY> not found" exception.

### DIFF
--- a/app/GitHub/Dto/Branch.php
+++ b/app/GitHub/Dto/Branch.php
@@ -11,4 +11,6 @@ class Branch extends DataTransferObject
     public $sha;
     public $user;
     public $repo;
+
+    protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/Issue.php
+++ b/app/GitHub/Dto/Issue.php
@@ -57,4 +57,6 @@ class Issue extends DataTransferObject
     public $labels_url;
     public $comments_url;
     public $events_url;
+
+    protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/Label.php
+++ b/app/GitHub/Dto/Label.php
@@ -13,4 +13,6 @@ class Label extends DataTransferObject
     public $color;
     public $default;
     public $description;
+
+    protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/Pr.php
+++ b/app/GitHub/Dto/Pr.php
@@ -73,4 +73,6 @@ class Pr extends DataTransferObject
     public $review_comment_url;
     public $statuses_url;
     public $_links;
+
+    protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/User.php
+++ b/app/GitHub/Dto/User.php
@@ -24,4 +24,6 @@ class User extends DataTransferObject
     public $received_events_url;
     public $type;
     public $site_admin;
+
+    protected $ignoreMissing = true;
 }


### PR DESCRIPTION
Currently, `spatie/data-transfer-object` throws an exception if it encounters a field in the data returned by Github that is not explicitly defined in Ozzies DTOs. This is problematic as GitHub periodically adds new fields to their API.

This PR relaxes that behavior as it is good enough that Ozzie defines the fields it needs and ignores anything else.

**Note:** on 17-JUL-2020, I accessed Ozzie and saw the standard Laravel '500 | Server Error' page. I can't access the production server to see what was happening so I checked my local dev environment. I discovered a new field `performed_via_github_app` was coming back from Github and caused the above error. 

Hopefully, this is what is happening in production :shrug: 