### PR TITLE
Remove unused properties from GitHub DTOs.

### DIFF
--- a/app/GitHub/Dto/Issue.php
+++ b/app/GitHub/Dto/Issue.php
@@ -12,51 +12,18 @@ class Issue extends DataTransferObject
     {
         parent::__construct($parameters);
         $this->toCarbon($this->created_at);
-        $this->toCarbon($this->updated_at);
-        $this->toCarbon($this->closed_at);
     }
 
-    // Identifiers -------------------------------------------------------------
-
-    public $id;
-    public $node_id;
-
-    // Details -----------------------------------------------------------------
-
-    public $number;
+    public $created_at;
+    public $html_url;
+    public $pull_request;
     public $title;
-    public $body;
-    public $comments;
+
     /** @var \App\GitHub\Dto\Label[] */
     public $labels;
-    public $state;
-    public $locked;
-    public $active_lock_reason;
-    public $milestone;
-
-    // People ------------------------------------------------------------------
 
     /** @var \App\GitHub\Dto\User */
     public $user;
-    public $assignee;
-    public $assignees;
-    public $author_association;
-    public $pull_request;
-
-    // Dates -------------------------------------------------------------------
-
-    public $created_at;
-    public $updated_at;
-    public $closed_at;
-
-    // Urls --------------------------------------------------------------------
-
-    public $html_url;
-    public $url;
-    public $repository_url;
-    public $labels_url;
-    public $comments_url;
-    public $events_url;
 
     protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/Label.php
+++ b/app/GitHub/Dto/Label.php
@@ -6,13 +6,8 @@ use Spatie\DataTransferObject\DataTransferObject;
 
 class Label extends DataTransferObject
 {
-    public $id;
-    public $node_id;
-    public $url;
-    public $name;
     public $color;
-    public $default;
-    public $description;
+    public $name;
 
     protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/Pr.php
+++ b/app/GitHub/Dto/Pr.php
@@ -12,67 +12,27 @@ class Pr extends DataTransferObject
     {
         parent::__construct($parameters);
         $this->toCarbon($this->created_at);
-        $this->toCarbon($this->updated_at);
-        $this->toCarbon($this->closed_at);
-        $this->toCarbon($this->merged_at);
     }
 
-    // Identifiers -------------------------------------------------------------
-
-    public $id;
+    public $body;
+    public $created_at;
+    public $draft;
+    public $html_url;
     public $node_id;
-    public $merge_commit_sha;
-
-    // Details -----------------------------------------------------------------
-
     public $number;
     public $title;
-    public $body;
-    /** @var \App\GitHub\Dto\Label[] */
-    public $labels;
-    public $state;
-    public $locked;
-    public $active_lock_reason;
-    public $milestone;
-    public $draft;
 
-    // People ------------------------------------------------------------------
-
-    /** @var \App\GitHub\Dto\User */
-    public $user;
-    public $assignee;
-    public $assignees;
-    public $requested_reviewers;
-    public $author_association;
-    public $requested_teams;
-
-    // Dates -------------------------------------------------------------------
-
-    public $created_at;
-    public $updated_at;
-    public $closed_at;
-    public $merged_at;
-
-    // Branches -------------------------------------------------------------------
-
-    /** @var \App\GitHub\Dto\Branch */
-    public $head;
     /** @var \App\GitHub\Dto\Branch */
     public $base;
 
-    // Urls --------------------------------------------------------------------
+    /** @var \App\GitHub\Dto\Branch */
+    public $head;
 
-    public $html_url;
-    public $url;
-    public $comments_url;
-    public $diff_url;
-    public $patch_url;
-    public $issue_url;
-    public $commits_url;
-    public $review_comments_url;
-    public $review_comment_url;
-    public $statuses_url;
-    public $_links;
+    /** @var \App\GitHub\Dto\Label[] */
+    public $labels;
+
+    /** @var \App\GitHub\Dto\User */
+    public $user;
 
     protected $ignoreMissing = true;
 }

--- a/app/GitHub/Dto/User.php
+++ b/app/GitHub/Dto/User.php
@@ -6,24 +6,8 @@ use Spatie\DataTransferObject\DataTransferObject;
 
 class User extends DataTransferObject
 {
-    public $login;
-    public $id;
-    public $node_id;
-    public $avatar_url;
-    public $gravatar_id;
-    public $url;
     public $html_url;
-    public $followers_url;
-    public $following_url;
-    public $gists_url;
-    public $starred_url;
-    public $subscriptions_url;
-    public $organizations_url;
-    public $repos_url;
-    public $events_url;
-    public $received_events_url;
-    public $type;
-    public $site_admin;
+    public $login;
 
     protected $ignoreMissing = true;
 }


### PR DESCRIPTION
As discussed [here](https://github.com/tightenco/ozzie/pull/49#issuecomment-660395477), this PR removes fields from the GitHub DTOs that Ozzie does not use.